### PR TITLE
Some issues with variables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.1.2 (unreleased)
+------------------
+
+- Fix for issue #2 (missing variable package.url)
+  [cedricmessiant]
+
+
 0.1.1 (2012-12-18)
 ------------------
 

--- a/bobtemplates/plone/.mrbob.ini
+++ b/bobtemplates/plone/.mrbob.ini
@@ -20,6 +20,10 @@ package.version.question = Version of the package
 package.version.default = 0.1
 package.version.help = Should be something like '0.1'.
 
+package.url.question = URL of the package                                      
+package.url.required = True                                                    
+package.url.help = The URL of the package. Should be something like 'http://pypi.python.org/pypi/plone.api/1.0'.
+
 author.name.question = Author's name
 author.name.required = True
 author.name.help = Should be something like 'John Smith'.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '0.1.1'
+version = '0.1.2.dev0'
 
 setup(
     name='bobtemplates.niteoweb',

--- a/test_answers.ini
+++ b/test_answers.ini
@@ -5,6 +5,7 @@ package.name = foo
 package.description = Dummy package
 package.keywords = Plone Travis-CI
 package.version = 0.1
+package.url = http://http://pypi.python.org/pypi/collective.foo/0.1
 
 author.name = The Plone Collective
 author.email = collective@plone.org


### PR DESCRIPTION
There is no question for the variable 'package.url' but it is required

(I got this error when I tried the template :
File "", line 34, in top-level template code
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'url'

and when I added a question for package.url, the template works perfectly)
